### PR TITLE
Fix deprecated use of module.run

### DIFF
--- a/django/post_deploy.sls
+++ b/django/post_deploy.sls
@@ -4,7 +4,7 @@
 {% if django.automatic_migrations %}
 migrate_database:
   module.run:
-    - name: django.command
+  - django.command:
     - settings_module: {{ django.settings_module }}
     - pythonpath: /opt/{{ app_name }}
     - command: migrate
@@ -15,7 +15,7 @@ migrate_database:
 
 collect_static_assets:
   module.run:
-    - name: django.collectstatic
+  - django.collectstatic:
     - settings_module: {{ django.settings_module }}
     - pythonpath: /opt/{{ app_name }}
     - bin_env: {{ django.django_admin_path }}


### PR DESCRIPTION
Our use of `module.run` will be deprecated in salt `3001` based on this [doc](https://docs.saltstack.com/en/latest/ref/states/all/salt.states.module.html) and this change fixes it.